### PR TITLE
Fix: Monster movement - chapter 4 examples 2 & 3

### DIFF
--- a/chapter-4/example-2-first-monster/monster.js
+++ b/chapter-4/example-2-first-monster/monster.js
@@ -17,7 +17,7 @@ export default class BasicMonster {
         let oldX = this.x
         let oldY = this.y
     
-        if (this.movementPoints > 0) {
+        if (this.movementPoints > 0 && !this.moving) {
             // https://github.com/qiao/PathFinding.js
             let pX = dungeon.player.x
             let pY = dungeon.player.y

--- a/chapter-4/example-2-first-monster/monster.js
+++ b/chapter-4/example-2-first-monster/monster.js
@@ -6,6 +6,7 @@ export default class BasicMonster {
         this.x = x
         this.y = y
         this.tile = 26
+        this.moving = false
         dungeon.initializeEntity(this)
     }
 

--- a/chapter-4/example-3-basic-combat/monster.js
+++ b/chapter-4/example-3-basic-combat/monster.js
@@ -9,6 +9,7 @@ export default class BasicMonster {
         this.x = x
         this.y = y
         this.tile = 26
+        this.moving = false
         dungeon.initializeEntity(this)
     }
 

--- a/chapter-4/example-3-basic-combat/monster.js
+++ b/chapter-4/example-3-basic-combat/monster.js
@@ -32,7 +32,7 @@ export default class BasicMonster {
         let finder = new PF.AStarFinder()
         let path = finder.findPath(oldX, oldY, pX, pY, grid)
 
-        if (this.movementPoints > 0) {
+        if (this.movementPoints > 0 && !this.moving) {
             if (path.length > 2) {
                 dungeon.moveEntityTo(this, path[1][0], path[1][1])
             }


### PR DESCRIPTION
Added a missing condition to the "turn()" method in "monster.js" to ensure the monster moves the number of times specified by "movementPoints".  

Currently, movementPoints decrements while the monster is moving.  If movementPoints' value is relatively low (ie. 1 <= x <= 10), the monster will only move once.  If movementPoints' value is relatively high (ie. 20 <= x <= 100), the monster will move more than once, but still less than the value specified by movementPoints.

This change ensures the monster moves "movementPoints" number of times.